### PR TITLE
fix: add symlink archive/template -> ../template

### DIFF
--- a/archive/template
+++ b/archive/template
@@ -1,0 +1,1 @@
+../template


### PR DESCRIPTION
- Create symlink to allow archived notes to access template files
- Symlink works with --root ../ parameter in both local and CI environments
- No need to modify typst compile commands